### PR TITLE
fix: stabilize explicit-sync and NVDEC lifecycles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ pollster = "0.4"
 
 # Wayland
 wayland-client = "0.31"
+wayland-protocols = { version = "0.32", features = ["client"] }
 smithay-client-toolkit = { version = "0.19", default-features = false, features = ["calloop"] }
 wayland-backend = { version = "0.3", features = ["client_system"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,5 +87,5 @@ hex = "0.4"
 humansize = "2"
 
 # Video support
-ffmpeg-next = { version = "8.1", default-features = false, features = ["codec", "format", "software-resampling", "software-scaling"] }
+ffmpeg-next = { version = "9.0", default-features = false, features = ["codec", "format", "software-resampling", "software-scaling"] }
 crossbeam-channel = "0.5"

--- a/wallr-core/Cargo.toml
+++ b/wallr-core/Cargo.toml
@@ -53,6 +53,7 @@ bytemuck = { version = "1.25", features = ["derive"] }
 
 # Wayland
 wayland-client.workspace = true
+wayland-protocols.workspace = true
 smithay-client-toolkit.workspace = true
 wayland-backend.workspace = true
 

--- a/wallr-core/src/daemon/mod.rs
+++ b/wallr-core/src/daemon/mod.rs
@@ -88,6 +88,8 @@ struct WaylandState {
     shm: Shm,
     outputs: std::collections::HashMap<u32, OutputInfo>,
     surfaces: Vec<(u32, LayerSurface)>,
+    pending_restores:
+        std::collections::HashMap<u32, (String, std::sync::Arc<tokio::sync::Mutex<RenderState>>)>,
     /// Layer shell protocol object for creating background surfaces.
     layer_shell: LayerShell,
     /// Compositor protocol object for creating input regions.
@@ -192,7 +194,31 @@ impl LayerShellHandler for WaylandState {
         _configure: LayerSurfaceConfigure,
         _serial: u32,
     ) {
-        layer.commit();
+        // SCTK acknowledges the configure. wgpu owns subsequent buffer commits,
+        // which must not race with a bufferless commit when explicit sync is active.
+        let output_id = self.surfaces.iter().find_map(|(output_id, surface)| {
+            (surface.wl_surface().id() == layer.wl_surface().id()).then_some(*output_id)
+        });
+        let Some((name, render_state)) = output_id.and_then(|id| self.pending_restores.remove(&id))
+        else {
+            return;
+        };
+        let Some(render_states) = self
+            .hotplug
+            .as_ref()
+            .map(|hotplug| hotplug.render_states.clone())
+        else {
+            return;
+        };
+
+        tokio::spawn(async move {
+            render_states
+                .lock()
+                .await
+                .insert(name.clone(), render_state.clone());
+            restore_cached_wallpaper(&name, &render_state).await;
+            tracing::info!("Output configured: {name}");
+        });
     }
 
     fn closed(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _layer: &LayerSurface) {}
@@ -259,7 +285,6 @@ impl OutputHandler for WaylandState {
             let renderer = self.hotplug.as_ref().unwrap().renderer.clone();
             let display_ptr = self.hotplug.as_ref().unwrap().display_ptr.0;
             let config = self.hotplug.as_ref().unwrap().config.clone();
-            let render_states = self.hotplug.as_ref().unwrap().render_states.clone();
             match create_render_state_for_output_sync(
                 &renderer,
                 display_ptr,
@@ -270,25 +295,7 @@ impl OutputHandler for WaylandState {
             ) {
                 Ok(rs) => {
                     let rs = std::sync::Arc::new(tokio::sync::Mutex::new(rs));
-                    tokio::spawn(async move {
-                        render_states.lock().await.insert(name.clone(), rs.clone());
-
-                        // Restore per-output last wallpaper.
-                        let state_path = dirs::cache_dir()
-                            .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-                            .join(format!("wallr/last_wallpaper/{name}"));
-                        if let Ok(path_str) = std::fs::read_to_string(&state_path) {
-                            let p = std::path::Path::new(path_str.trim());
-                            if p.exists() {
-                                let mut lock = rs.lock().await;
-                                let effect = crate::animation::Effect::Fade(
-                                    crate::animation::FadeParams::default(),
-                                );
-                                let _ = lock.set_wallpaper(p, &effect, 1000, 0).await;
-                            }
-                        }
-                        tracing::info!("Hotplug: output {name} ready");
-                    });
+                    self.pending_restores.insert(id, (name, rs));
                 }
                 Err(e) => {
                     tracing::error!("Hotplug: failed to create render state for {name}: {e}");
@@ -707,6 +714,25 @@ impl RenderState {
                 &per_output_uniforms,
             );
         }));
+    }
+}
+
+async fn restore_cached_wallpaper(name: &str, render_state: &Arc<Mutex<RenderState>>) {
+    let state_path = dirs::cache_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+        .join(format!("wallr/last_wallpaper/{name}"));
+    let Ok(path_str) = std::fs::read_to_string(state_path) else {
+        return;
+    };
+    let path = std::path::Path::new(path_str.trim());
+    if !path.exists() {
+        return;
+    }
+
+    let mut state = render_state.lock().await;
+    let effect = crate::animation::Effect::Fade(crate::animation::FadeParams::default());
+    if let Err(err) = state.set_wallpaper(path, &effect, 1000, 0).await {
+        tracing::warn!("Failed to restore wallpaper for {name}: {err}");
     }
 }
 
@@ -1174,6 +1200,7 @@ impl Daemon {
             shm,
             outputs: std::collections::HashMap::new(),
             surfaces: Vec::new(),
+            pending_restores: std::collections::HashMap::new(),
             layer_shell,
             compositor,
             hotplug: None,
@@ -1244,20 +1271,9 @@ impl Daemon {
             .await?;
             let rs = Arc::new(Mutex::new(rs));
             render_states_map.insert(name.clone(), rs.clone());
-
-            // Restore per-output last wallpaper.
-            let state_path = dirs::cache_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-                .join(format!("wallr/last_wallpaper/{name}"));
-            if let Ok(path_str) = std::fs::read_to_string(&state_path) {
-                let p = std::path::Path::new(path_str.trim());
-                if p.exists() {
-                    let mut lock = rs.lock().await;
-                    let effect =
-                        crate::animation::Effect::Fade(crate::animation::FadeParams::default());
-                    let _ = lock.set_wallpaper(p, &effect, 1000, 0).await;
-                }
-            }
+            wayland_state
+                .pending_restores
+                .insert(*proto_id, (name.clone(), rs));
 
             tracing::info!("Output ready: {name} ({proto_id})");
         }
@@ -1506,6 +1522,12 @@ impl Daemon {
                         }
                     }
                     IpcCommand::Stop => {
+                        for rs in render_states.values() {
+                            let state = rs.lock().await;
+                            state.playback_gen.fetch_add(1, Ordering::SeqCst);
+                            state.pacer.notify();
+                            state.video_playback.stop();
+                        }
                         let sp = stop_socket.clone();
                         tokio::spawn(async move {
                             tokio::time::sleep(std::time::Duration::from_millis(300)).await;
@@ -1985,15 +2007,14 @@ impl Daemon {
         layer_surface
             .wl_surface()
             .set_input_region(Some(&empty_region));
-        layer_surface.commit();
-        empty_region.destroy();
-
         let scale_factor = if output.scale_factor > 0 {
             output.scale_factor
         } else {
             1
         };
         layer_surface.wl_surface().set_buffer_scale(scale_factor);
+        layer_surface.commit();
+        empty_region.destroy();
 
         // mode.dimensions already returns physical pixels; do not multiply by scale.
         let width = output.width;
@@ -2103,15 +2124,14 @@ fn create_render_state_for_output_sync(
     layer_surface
         .wl_surface()
         .set_input_region(Some(&empty_region));
-    layer_surface.commit();
-    empty_region.destroy();
-
     let scale_factor = if output.scale_factor > 0 {
         output.scale_factor
     } else {
         1
     };
     layer_surface.wl_surface().set_buffer_scale(scale_factor);
+    layer_surface.commit();
+    empty_region.destroy();
 
     // mode.dimensions already returns physical pixels; do not multiply by scale.
     let width = output.width;

--- a/wallr-core/src/daemon/mod.rs
+++ b/wallr-core/src/daemon/mod.rs
@@ -81,6 +81,13 @@ struct OutputInfo {
     wl_output: wl_output::WlOutput,
 }
 
+#[derive(Clone)]
+struct OutputLifecycle {
+    name: String,
+    render_state: std::sync::Arc<tokio::sync::Mutex<RenderState>>,
+    active: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
 struct WaylandState {
     registry_state: RegistryState,
     output_state: OutputState,
@@ -88,8 +95,8 @@ struct WaylandState {
     shm: Shm,
     outputs: std::collections::HashMap<u32, OutputInfo>,
     surfaces: Vec<(u32, LayerSurface)>,
-    pending_restores:
-        std::collections::HashMap<u32, (String, std::sync::Arc<tokio::sync::Mutex<RenderState>>)>,
+    output_lifecycles: std::collections::HashMap<u32, OutputLifecycle>,
+    pending_restores: std::collections::HashSet<u32>,
     /// Layer shell protocol object for creating background surfaces.
     layer_shell: LayerShell,
     /// Compositor protocol object for creating input regions.
@@ -199,8 +206,10 @@ impl LayerShellHandler for WaylandState {
         let output_id = self.surfaces.iter().find_map(|(output_id, surface)| {
             (surface.wl_surface().id() == layer.wl_surface().id()).then_some(*output_id)
         });
-        let Some((name, render_state)) = output_id.and_then(|id| self.pending_restores.remove(&id))
-        else {
+        let Some(output_id) = output_id.filter(|id| self.pending_restores.remove(id)) else {
+            return;
+        };
+        let Some(lifecycle) = self.output_lifecycles.get(&output_id).cloned() else {
             return;
         };
         let Some(render_states) = self
@@ -212,12 +221,16 @@ impl LayerShellHandler for WaylandState {
         };
 
         tokio::spawn(async move {
-            render_states
-                .lock()
-                .await
-                .insert(name.clone(), render_state.clone());
-            restore_cached_wallpaper(&name, &render_state).await;
-            tracing::info!("Output configured: {name}");
+            if !lifecycle.active.load(Ordering::SeqCst) {
+                return;
+            }
+            restore_cached_wallpaper(&lifecycle.name, &lifecycle.render_state).await;
+
+            let mut states = render_states.lock().await;
+            if lifecycle.active.load(Ordering::SeqCst) {
+                states.insert(lifecycle.name.clone(), lifecycle.render_state);
+                tracing::info!("Output configured: {}", lifecycle.name);
+            }
         });
     }
 
@@ -295,7 +308,15 @@ impl OutputHandler for WaylandState {
             ) {
                 Ok(rs) => {
                     let rs = std::sync::Arc::new(tokio::sync::Mutex::new(rs));
-                    self.pending_restores.insert(id, (name, rs));
+                    self.output_lifecycles.insert(
+                        id,
+                        OutputLifecycle {
+                            name,
+                            render_state: rs,
+                            active: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+                        },
+                    );
+                    self.pending_restores.insert(id);
                 }
                 Err(e) => {
                     tracing::error!("Hotplug: failed to create render state for {name}: {e}");
@@ -405,18 +426,31 @@ impl OutputHandler for WaylandState {
         let id = output.id().protocol_id();
         if let Some(info) = self.outputs.remove(&id) {
             tracing::info!("Output disconnected: {} (protocol_id={})", info.name, id);
+            self.pending_restores.remove(&id);
+            let lifecycle = self.output_lifecycles.remove(&id);
+            if let Some(lifecycle) = &lifecycle {
+                lifecycle.active.store(false, Ordering::SeqCst);
+            }
             // Remove the LayerSurface from our tracking list.
             self.surfaces.retain(|(pid, _)| *pid != id);
             // Remove the render state from the shared map and stop playback.
-            if let Some(ref hotplug) = self.hotplug {
-                let name = info.name.clone();
+            if let (Some(hotplug), Some(lifecycle)) = (&self.hotplug, lifecycle) {
                 let render_states = hotplug.render_states.clone();
                 tokio::spawn(async move {
-                    if let Some(rs) = render_states.lock().await.remove(&name) {
-                        let lock = rs.lock().await;
-                        lock.video_playback.stop();
-                        tracing::info!("Hotplug: cleaned up render state for {name}");
+                    let mut states = render_states.lock().await;
+                    if states
+                        .get(&lifecycle.name)
+                        .is_some_and(|state| Arc::ptr_eq(state, &lifecycle.render_state))
+                    {
+                        states.remove(&lifecycle.name);
                     }
+                    drop(states);
+
+                    let state = lifecycle.render_state.lock().await;
+                    state.playback_gen.fetch_add(1, Ordering::SeqCst);
+                    state.pacer.notify();
+                    state.video_playback.stop();
+                    tracing::info!("Hotplug: cleaned up render state for {}", lifecycle.name);
                 });
             }
         }
@@ -1200,7 +1234,8 @@ impl Daemon {
             shm,
             outputs: std::collections::HashMap::new(),
             surfaces: Vec::new(),
-            pending_restores: std::collections::HashMap::new(),
+            output_lifecycles: std::collections::HashMap::new(),
+            pending_restores: std::collections::HashSet::new(),
             layer_shell,
             compositor,
             hotplug: None,
@@ -1236,7 +1271,7 @@ impl Daemon {
         // Create a LayerSurface, wgpu Surface, and RenderState for every
         // known output. The key is the output's human-readable name (e.g.
         // "DP-1", "eDP-1") so IPC can target a specific monitor.
-        let mut render_states_map: std::collections::HashMap<String, Arc<Mutex<RenderState>>> =
+        let render_states_map: std::collections::HashMap<String, Arc<Mutex<RenderState>>> =
             std::collections::HashMap::new();
 
         // Collect output info first so we can pass &mut wayland_state to the
@@ -1270,10 +1305,15 @@ impl Daemon {
             )
             .await?;
             let rs = Arc::new(Mutex::new(rs));
-            render_states_map.insert(name.clone(), rs.clone());
-            wayland_state
-                .pending_restores
-                .insert(*proto_id, (name.clone(), rs));
+            wayland_state.output_lifecycles.insert(
+                *proto_id,
+                OutputLifecycle {
+                    name: name.clone(),
+                    render_state: rs,
+                    active: Arc::new(std::sync::atomic::AtomicBool::new(true)),
+                },
+            );
+            wayland_state.pending_restores.insert(*proto_id);
 
             tracing::info!("Output ready: {name} ({proto_id})");
         }

--- a/wallr-core/src/daemon/mod.rs
+++ b/wallr-core/src/daemon/mod.rs
@@ -26,9 +26,13 @@ use smithay_client_toolkit::{
     shm::{Shm, ShmHandler},
 };
 use wayland_client::{
-    Connection, Proxy, QueueHandle,
+    Connection, Dispatch, Proxy, QueueHandle,
     globals::registry_queue_init,
     protocol::{wl_compositor, wl_output, wl_surface},
+};
+use wayland_protocols::wp::viewporter::client::{
+    wp_viewport::{self, WpViewport},
+    wp_viewporter::{self, WpViewporter},
 };
 #[derive(Debug, thiserror::Error)]
 pub enum DaemonError {
@@ -95,6 +99,8 @@ struct WaylandState {
     shm: Shm,
     outputs: std::collections::HashMap<u32, OutputInfo>,
     surfaces: Vec<(u32, LayerSurface)>,
+    viewporter: Option<WpViewporter>,
+    viewports: std::collections::HashMap<u32, WpViewport>,
     output_lifecycles: std::collections::HashMap<u32, OutputLifecycle>,
     pending_restores: std::collections::HashSet<u32>,
     /// Layer shell protocol object for creating background surfaces.
@@ -192,13 +198,84 @@ impl wayland_client::Dispatch<wayland_client::protocol::wl_region::WlRegion, ()>
     }
 }
 
+impl Dispatch<WpViewporter, ()> for WaylandState {
+    fn event(
+        _state: &mut WaylandState,
+        _proxy: &WpViewporter,
+        _event: wp_viewporter::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<WaylandState>,
+    ) {
+    }
+}
+
+impl Dispatch<WpViewport, ()> for WaylandState {
+    fn event(
+        _state: &mut WaylandState,
+        _proxy: &WpViewport,
+        _event: wp_viewport::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<WaylandState>,
+    ) {
+    }
+}
+
+fn viewport_destination(configured: (u32, u32), physical: (u32, u32)) -> Option<(i32, i32)> {
+    let (width, height) = configured;
+    let (physical_width, physical_height) = physical;
+    match (width, height) {
+        (0, 0) => None,
+        (0, height) if physical_height > 0 => {
+            let width = (u64::from(height) * u64::from(physical_width)
+                + u64::from(physical_height) / 2)
+                / u64::from(physical_height);
+            Some((i32::try_from(width).ok()?, i32::try_from(height).ok()?))
+        }
+        (width, 0) if physical_width > 0 => {
+            let height = (u64::from(width) * u64::from(physical_height)
+                + u64::from(physical_width) / 2)
+                / u64::from(physical_width);
+            Some((i32::try_from(width).ok()?, i32::try_from(height).ok()?))
+        }
+        (width, height) => Some((i32::try_from(width).ok()?, i32::try_from(height).ok()?)),
+    }
+}
+
+#[cfg(test)]
+mod viewport_tests {
+    use super::viewport_destination;
+
+    #[test]
+    fn preserves_complete_configure_size() {
+        assert_eq!(
+            viewport_destination((3072, 1728), (3840, 2160)),
+            Some((3072, 1728))
+        );
+    }
+
+    #[test]
+    fn derives_missing_dimension_from_physical_aspect_ratio() {
+        assert_eq!(
+            viewport_destination((0, 1728), (3840, 2160)),
+            Some((3072, 1728))
+        );
+        assert_eq!(
+            viewport_destination((3072, 0), (3840, 2160)),
+            Some((3072, 1728))
+        );
+        assert_eq!(viewport_destination((0, 0), (3840, 2160)), None);
+    }
+}
+
 impl LayerShellHandler for WaylandState {
     fn configure(
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
         layer: &LayerSurface,
-        _configure: LayerSurfaceConfigure,
+        configure: LayerSurfaceConfigure,
         _serial: u32,
     ) {
         // SCTK acknowledges the configure. wgpu owns subsequent buffer commits,
@@ -206,9 +283,27 @@ impl LayerShellHandler for WaylandState {
         let output_id = self.surfaces.iter().find_map(|(output_id, surface)| {
             (surface.wl_surface().id() == layer.wl_surface().id()).then_some(*output_id)
         });
-        let Some(output_id) = output_id.filter(|id| self.pending_restores.remove(id)) else {
+        let Some(output_id) = output_id else {
             return;
         };
+        let destination = self.outputs.get(&output_id).and_then(|output| {
+            viewport_destination(configure.new_size, (output.width, output.height))
+        });
+        if let Some(viewport) = self.viewports.get(&output_id) {
+            let Some((logical_width, logical_height)) = destination else {
+                tracing::warn!(
+                    "Output {output_id} configure omitted both dimensions; waiting for a usable size"
+                );
+                return;
+            };
+            viewport.set_destination(logical_width, logical_height);
+            tracing::debug!(
+                "Configured viewport destination for output {output_id}: {logical_width}x{logical_height}"
+            );
+        }
+        if !self.pending_restores.remove(&output_id) {
+            return;
+        }
         let Some(lifecycle) = self.output_lifecycles.get(&output_id).cloned() else {
             return;
         };
@@ -427,12 +522,16 @@ impl OutputHandler for WaylandState {
         if let Some(info) = self.outputs.remove(&id) {
             tracing::info!("Output disconnected: {} (protocol_id={})", info.name, id);
             self.pending_restores.remove(&id);
+            let viewport = self.viewports.remove(&id);
+            let layer_surface = self
+                .surfaces
+                .iter()
+                .position(|(pid, _)| *pid == id)
+                .map(|position| self.surfaces.swap_remove(position).1);
             let lifecycle = self.output_lifecycles.remove(&id);
             if let Some(lifecycle) = &lifecycle {
                 lifecycle.active.store(false, Ordering::SeqCst);
             }
-            // Remove the LayerSurface from our tracking list.
-            self.surfaces.retain(|(pid, _)| *pid != id);
             // Remove the render state from the shared map and stop playback.
             if let (Some(hotplug), Some(lifecycle)) = (&self.hotplug, lifecycle) {
                 let render_states = hotplug.render_states.clone();
@@ -450,8 +549,28 @@ impl OutputHandler for WaylandState {
                     state.playback_gen.fetch_add(1, Ordering::SeqCst);
                     state.pacer.notify();
                     state.video_playback.stop();
+                    let render_lock = state.render_lock.clone();
+                    drop(state);
+
+                    let _ = tokio::task::spawn_blocking(move || {
+                        drop(
+                            render_lock
+                                .lock()
+                                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+                        );
+                    })
+                    .await;
+                    if let Some(viewport) = viewport {
+                        viewport.destroy();
+                    }
+                    drop(layer_surface);
                     tracing::info!("Hotplug: cleaned up render state for {}", lifecycle.name);
                 });
+            } else {
+                if let Some(viewport) = viewport {
+                    viewport.destroy();
+                }
+                drop(layer_surface);
             }
         }
     }
@@ -1226,6 +1345,14 @@ impl Daemon {
                 smithay_client_toolkit::globals::GlobalData,
             )
             .map_err(|e| DaemonError::StartError(format!("compositor bind failed: {e:?}")))?;
+        let viewporter = globals
+            .bind::<WpViewporter, WaylandState, ()>(&qh, 1..=1, ())
+            .ok();
+        if viewporter.is_none() {
+            tracing::warn!(
+                "wp_viewporter is unavailable; fractional outputs will use integer buffer scaling"
+            );
+        }
 
         let mut wayland_state = WaylandState {
             registry_state: RegistryState::new(&globals),
@@ -1234,6 +1361,8 @@ impl Daemon {
             shm,
             outputs: std::collections::HashMap::new(),
             surfaces: Vec::new(),
+            viewporter,
+            viewports: std::collections::HashMap::new(),
             output_lifecycles: std::collections::HashMap::new(),
             pending_restores: std::collections::HashSet::new(),
             layer_shell,
@@ -2047,7 +2176,14 @@ impl Daemon {
         layer_surface
             .wl_surface()
             .set_input_region(Some(&empty_region));
-        let scale_factor = if output.scale_factor > 0 {
+        let output_id = output.wl_output.id().protocol_id();
+        let viewport = wayland_state
+            .viewporter
+            .as_ref()
+            .map(|viewporter| viewporter.get_viewport(layer_surface.wl_surface(), qh, ()));
+        let scale_factor = if viewport.is_some() {
+            1
+        } else if output.scale_factor > 0 {
             output.scale_factor
         } else {
             1
@@ -2055,15 +2191,16 @@ impl Daemon {
         layer_surface.wl_surface().set_buffer_scale(scale_factor);
         layer_surface.commit();
         empty_region.destroy();
+        if let Some(viewport) = viewport {
+            wayland_state.viewports.insert(output_id, viewport);
+        }
 
         // mode.dimensions already returns physical pixels; do not multiply by scale.
         let width = output.width;
         let height = output.height;
 
         let raw_surface = layer_surface.wl_surface().id().as_ptr() as *mut std::ffi::c_void;
-        wayland_state
-            .surfaces
-            .push((output.wl_output.id().protocol_id(), layer_surface));
+        wayland_state.surfaces.push((output_id, layer_surface));
 
         let window_handle = WaylandWindow {
             display: display_ptr,
@@ -2164,7 +2301,14 @@ fn create_render_state_for_output_sync(
     layer_surface
         .wl_surface()
         .set_input_region(Some(&empty_region));
-    let scale_factor = if output.scale_factor > 0 {
+    let output_id = output.wl_output.id().protocol_id();
+    let viewport = wayland_state
+        .viewporter
+        .as_ref()
+        .map(|viewporter| viewporter.get_viewport(layer_surface.wl_surface(), qh, ()));
+    let scale_factor = if viewport.is_some() {
+        1
+    } else if output.scale_factor > 0 {
         output.scale_factor
     } else {
         1
@@ -2172,15 +2316,16 @@ fn create_render_state_for_output_sync(
     layer_surface.wl_surface().set_buffer_scale(scale_factor);
     layer_surface.commit();
     empty_region.destroy();
+    if let Some(viewport) = viewport {
+        wayland_state.viewports.insert(output_id, viewport);
+    }
 
     // mode.dimensions already returns physical pixels; do not multiply by scale.
     let width = output.width;
     let height = output.height;
 
     let raw_surface = layer_surface.wl_surface().id().as_ptr() as *mut std::ffi::c_void;
-    wayland_state
-        .surfaces
-        .push((output.wl_output.id().protocol_id(), layer_surface));
+    wayland_state.surfaces.push((output_id, layer_surface));
 
     let window_handle = WaylandWindow {
         display: display_ptr,

--- a/wallr-core/src/video/decoder.rs
+++ b/wallr-core/src/video/decoder.rs
@@ -432,10 +432,11 @@ impl VideoDecoder {
                         break 'outer;
                     }
 
-                    let is_hw_frame = unsafe { (*decoded_frame.as_ptr()).data[0].is_null() };
+                    let is_hw_frame = unsafe { !(*decoded_frame.as_ptr()).hw_frames_ctx.is_null() };
 
                     let src_frame = if is_hw_frame {
                         let ret = unsafe {
+                            ffmpeg::ffi::av_frame_unref(sw_frame.as_mut_ptr());
                             ffmpeg::ffi::av_hwframe_transfer_data(
                                 sw_frame.as_mut_ptr(),
                                 decoded_frame.as_ptr(),

--- a/wallr-core/src/video/playback.rs
+++ b/wallr-core/src/video/playback.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 pub struct VideoPlayback {
     decoder: Mutex<Option<VideoDecoder>>,
     scheduler: Mutex<Option<FrameScheduler>>,
+    pending_frame: Mutex<Option<VideoFrame>>,
     current_frame: Mutex<Option<VideoFrame>>,
 }
 
@@ -16,6 +17,7 @@ impl VideoPlayback {
         Self {
             decoder: Mutex::new(None),
             scheduler: Mutex::new(None),
+            pending_frame: Mutex::new(None),
             current_frame: Mutex::new(None),
         }
     }
@@ -44,6 +46,7 @@ impl VideoPlayback {
     pub fn stop(&self) {
         *self.lock_decoder() = None;
         *self.lock_scheduler() = None;
+        *self.lock_pending() = None;
         *self.lock_current() = None;
     }
 
@@ -66,18 +69,20 @@ impl VideoPlayback {
     }
 
     pub fn seek(&self, timestamp: Duration) -> Result<(), crate::video::error::VideoError> {
-        {
-            let mut decoder = self.lock_decoder();
-            let mut scheduler = self.lock_scheduler();
-            let scheduler = scheduler.as_mut().ok_or_else(|| {
-                VideoError::SeekFailed(timestamp, anyhow::anyhow!("no video is playing"))
-            })?;
-            scheduler.seek(timestamp)?;
-            if let Some(d) = decoder.as_mut() {
-                d.seek(timestamp);
-                d.drain();
-            }
+        let mut decoder = self.lock_decoder();
+        let mut scheduler = self.lock_scheduler();
+        let mut pending = self.lock_pending();
+        let mut current = self.lock_current();
+        let scheduler = scheduler.as_mut().ok_or_else(|| {
+            VideoError::SeekFailed(timestamp, anyhow::anyhow!("no video is playing"))
+        })?;
+        scheduler.seek(timestamp)?;
+        if let Some(d) = decoder.as_mut() {
+            d.seek(timestamp);
+            d.drain();
         }
+        *pending = None;
+        *current = None;
         tracing::info!("Video seeked to {:?}", timestamp);
         Ok(())
     }
@@ -85,16 +90,16 @@ impl VideoPlayback {
     pub fn next_frame(&self) -> Option<VideoFrame> {
         let mut decoder = self.lock_decoder();
         let mut scheduler = self.lock_scheduler();
+        let mut pending = self.lock_pending();
         let (Some(decoder), Some(scheduler)) = (decoder.as_mut(), scheduler.as_mut()) else {
             return None;
         };
-        while let Some(frame) = decoder.next_frame() {
-            if scheduler.should_display(frame.pts) && scheduler.should_upload(frame.pts) {
-                *self.lock_current() = Some(frame.clone());
-                return Some(frame);
-            }
+
+        let frame = take_due_frame(scheduler, &mut pending, || decoder.next_frame());
+        if let Some(frame) = &frame {
+            *self.lock_current() = Some(frame.clone());
         }
-        None
+        frame
     }
 
     pub fn wait_first_frame(&self, timeout: Duration) -> Option<VideoFrame> {
@@ -153,13 +158,91 @@ impl VideoPlayback {
         self.scheduler.lock().unwrap_or_else(|p| p.into_inner())
     }
 
+    fn lock_pending(&self) -> std::sync::MutexGuard<'_, Option<VideoFrame>> {
+        self.pending_frame.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
     fn lock_current(&self) -> std::sync::MutexGuard<'_, Option<VideoFrame>> {
         self.current_frame.lock().unwrap_or_else(|p| p.into_inner())
     }
 }
 
+fn take_due_frame(
+    scheduler: &mut FrameScheduler,
+    pending: &mut Option<VideoFrame>,
+    mut next_frame: impl FnMut() -> Option<VideoFrame>,
+) -> Option<VideoFrame> {
+    let mut selected = None;
+
+    if let Some(frame) = pending.take() {
+        if !scheduler.should_display(frame.pts) {
+            *pending = Some(frame);
+            return None;
+        }
+        if scheduler.should_upload(frame.pts) {
+            selected = Some(frame);
+        }
+    }
+
+    while let Some(frame) = next_frame() {
+        if !scheduler.should_display(frame.pts) {
+            *pending = Some(frame);
+            break;
+        }
+        if scheduler.should_upload(frame.pts) {
+            selected = Some(frame);
+        }
+    }
+
+    selected
+}
+
 impl Default for VideoPlayback {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+
+    fn frame(pts_ms: u64) -> VideoFrame {
+        VideoFrame {
+            data: vec![pts_ms as u8],
+            width: 1,
+            height: 1,
+            pts: Duration::from_millis(pts_ms),
+            index: pts_ms,
+        }
+    }
+
+    #[test]
+    fn retains_future_frame_until_due() {
+        let mut scheduler = FrameScheduler::new(Duration::from_secs(1));
+        let mut pending = None;
+        let mut frames = VecDeque::from([frame(0), frame(100)]);
+
+        let first = take_due_frame(&mut scheduler, &mut pending, || frames.pop_front()).unwrap();
+        assert_eq!(first.pts, Duration::ZERO);
+        assert_eq!(pending.as_ref().unwrap().pts, Duration::from_millis(100));
+
+        scheduler.seek(Duration::from_millis(110)).unwrap();
+        let second = take_due_frame(&mut scheduler, &mut pending, || None).unwrap();
+        assert_eq!(second.pts, Duration::from_millis(100));
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn selects_latest_due_frame() {
+        let mut scheduler = FrameScheduler::new(Duration::from_secs(1));
+        scheduler.seek(Duration::from_millis(50)).unwrap();
+        let mut pending = None;
+        let mut frames = VecDeque::from([frame(0), frame(16), frame(32), frame(100)]);
+
+        let selected = take_due_frame(&mut scheduler, &mut pending, || frames.pop_front()).unwrap();
+        assert_eq!(selected.pts, Duration::from_millis(32));
+        assert_eq!(pending.as_ref().unwrap().pts, Duration::from_millis(100));
     }
 }

--- a/wallr-core/src/video/scheduler.rs
+++ b/wallr-core/src/video/scheduler.rs
@@ -111,6 +111,12 @@ impl FrameScheduler {
         {
             return false;
         }
+        if let Some(last_pts) = self.last_frame_pts
+            && frame_pts < last_pts
+            && current >= last_pts
+        {
+            return false;
+        }
         frame_pts <= current
     }
 
@@ -203,5 +209,16 @@ mod tests {
         assert!(scheduler.should_upload(Duration::from_millis(100)));
         assert!(!scheduler.should_upload(Duration::from_millis(102)));
         assert!(scheduler.should_upload(Duration::from_millis(200)));
+    }
+
+    #[test]
+    fn test_waits_for_clock_before_decoder_wrap() {
+        let mut scheduler = FrameScheduler::new(Duration::from_secs(1));
+        scheduler.seek(Duration::from_millis(950)).unwrap();
+        assert!(scheduler.should_upload(Duration::from_millis(900)));
+        assert!(!scheduler.should_display(Duration::ZERO));
+
+        scheduler.start_time = Instant::now() - Duration::from_millis(10);
+        assert!(scheduler.should_display(Duration::ZERO));
     }
 }


### PR DESCRIPTION
## Summary
- update `ffmpeg-next` to 9.0 and correctly transfer NVDEC hardware frames
- avoid bufferless layer commits under explicit sync
- defer startup and hotplug restoration until layer configure, with cancellation-safe output lifecycle handling
- map native-resolution buffers to logical layer sizes through `wp_viewporter`
- retain future video frames until their PTS is due instead of discarding them
- stop active rendering and video playback before daemon exit or output teardown

## Root causes
SCTK already acknowledges layer-shell configure events. Wallr's extra `layer.commit()` raced wgpu-owned presentation and produced a bufferless explicit-sync commit, which NVIDIA rejected with `wp_linux_drm_syncobj_surface_v1: Missing buffer`.

Cached startup and hotplug restoration could attach a buffer before configure or race output removal. Restoration is now configure-gated and lifecycle-cancelled.

Fractionally scaled outputs combined physical mode dimensions with Wayland's integer buffer scale. Native buffers now remain at scale 1 and are mapped to the compositor-provided logical size through `wp_viewporter`.

The playback scheduler discarded decoded frames whose PTS was slightly in the future. NVDEC could therefore advance while the displayed frame remained frozen. Wallr now retains the first future frame and presents it when due.

## Verification
- `cargo fmt --all --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (46 passed)
- `cargo build --release --bin wallr`
- static images, GIF playback, IPC pause/resume/seek/info/blank/restore
- cached three-output startup with 3840x2160 H.264 at 60 FPS using NVDEC
- Wayland trace: DP-1 uses `set_buffer_scale(1)` and `wp_viewport.set_destination(3072, 1728)`
- scale-2 virtual output renders edge-to-edge without black bars
- captures across normal playback and the 19.95-second loop boundary contain changing wallpaper pixels
- configured hotplug removal and immediate pre-configure removal leave no stale IPC state
- IPC stop during NVDEC playback exits with systemd status 0 and no core dump

Fixes #12