### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ GPU-accelerated wallpaper engine for Wayland with native `wl-layer-shell` render
 
 ## Introduction
 
-Wallr sets and animates wallpapers on Wayland compositors that support `wlr-layer-shell`. It renders its own background surface with `wgpu` — it does not shell out to `hyprpaper`, `swww`, or `swaybg`.
+Wallr sets and animates wallpapers on Wayland compositors that support `wlr-layer-shell`. It renders its own background surface with `wgpu` — it does not shell out to `hyprpaper`, `awww`, or `swaybg`.
 
 Theme generation (Matugen, Wallust, Pywal) is supported as an optional step that runs after a wallpaper is applied. It is not required and not part of the core rendering path.
 


### PR DESCRIPTION
`swww` has been archived, it's new name is `awww`

## Summary by Sourcery

Update README references to use the renamed `awww` wallpaper tool.

Enhancements:
- Update the README to reference `awww` as the current wallpaper tool name.

Documentation:
- Refresh the README’s list of external wallpaper tools to replace the archived `swww` name with `awww`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that Wallr does not rely on external wallpaper tools such as `hyprpaper`, `awww`, or `swaybg`.
  * Removed the outdated reference to `swww`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->